### PR TITLE
Add DuckDuckGo as Google-Search alternative

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -689,6 +689,12 @@ const app = {
             t.title
           )}`;
         });
+        const duckduckgoLink = node.querySelectorAll('.duckduckgo-link, .duckduckgo-link-mobile');
+        duckduckgoLink.forEach((dl) => {
+          dl.href = `https://www.duckduckgo.com/?q=Fachinformatiker+AP1+${encodeURIComponent(
+              t.title
+          )}`;
+        });
 
         // -------------------------------------------------------------
         // NEUE GEWICHTUNGSLOGIK (1-5)

--- a/index.html
+++ b/index.html
@@ -622,6 +622,14 @@
                   >
                     <i class="fa-brands fa-google mr-1"></i>Suche
                   </a>
+                  <a
+                    href="#"
+                    target="_blank"
+                    class="duckduckgo-link hidden sm:inline-flex items-center text-dark-muted hover:text-dark-accent transition-colors text-[10px] bg-dark-bg px-2 py-1 rounded border border-dark-border uppercase tracking-wider font-bold"
+                    onclick="event.stopPropagation()"
+                  >
+                    DuckDuckGo
+                  </a>
                 </div>
               </div>
               <div
@@ -653,6 +661,14 @@
                   onclick="event.stopPropagation()"
                 >
                   <i class="fa-brands fa-google mr-1"></i> Google
+                </a>
+                <a
+                  href="#"
+                  target="_blank"
+                  class="duckduckgo-link-mobile sm:hidden inline-flex items-center text-dark-accent text-[10px] uppercase font-bold"
+                  onclick="event.stopPropagation()"
+                >
+                  DuckDuckGo
                 </a>
               </div>
               <ul class="subtask-list space-y-2.5"></ul>


### PR DESCRIPTION
# Zusammenfassung

Die PR fügt neben dem Google-Suche Button einen alternativen Button hinzu, um eine direkte Suche mit DuckDuckGo zu ermöglichen.

Der AP1-Tracker bietet eine wunderbare private Erfahrung zum Lernen, die durch eine fehlende Option für eine private Suchmaschine leider ein wenig _leidet_.

# Mögliche Verbesserung/ Anmerkungen

Was mir leider nicht gelungen ist, ist, wie beim Google-Suche Button, ein passendes Logo einzufügen. Ich habe bei fontawesome nach einem passenden gesucht - hatte nur leider keinen Erfolg.

Am liebsten hätte ich auch grundlegend im Sinne der Privatsphäre die Google-Option entfernt und ersetzt, anstatt die neue zu ergänzen. Da aber sicherlich einige User Google bevorzugen, wäre das ein zu radikaler Schritt. Nach kurzer Recherche habe ich auch keine Möglichkeit gefunden, die im Browser hinterlegte Suchmaschine zu verwenden.

Da ich leider auch keine Ahnung von Frontend-/Web-Development und insbesondere JS habe, habe ich davon abgesehen, größere Änderungen zu versuchen. Eine Änderung wäre beispielsweise, die Möglichkeit eine Default-Suchmaschine für den AP1-Tracker für den User konfigurierbar zu machen.

# Dankeschön

Lange Rede - gar kein Sinn:
Von mir auch noch ein dickes dickes **Dankeschön** für dieses Tool. Auch der Privacy-First-Ansatz ist sehr lobenswert.
 # ❤️❤️❤️